### PR TITLE
feat: add calendar preview 

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -4,5 +4,14 @@ export default defineAppConfig({
       primary: 'purple',
       neutral: 'slate',
     },
+    modal: {
+      variants: {
+        fullscreen: {
+          true: {
+            content: 'top-[50%] left-[50%] translate-x-[-50%] translate-y-[-50%] sm:max-w-4xl sm:h-auto sm:max-h-[calc(100vh-4rem)] sm:rounded-[calc(var(--ui-radius)*2)] sm:shadow-lg sm:ring ring-[var(--ui-border)]',
+          },
+        },
+      },
+    },
   },
 })

--- a/app.config.ts
+++ b/app.config.ts
@@ -8,7 +8,7 @@ export default defineAppConfig({
       variants: {
         fullscreen: {
           true: {
-            content: 'top-[50%] left-[50%] translate-x-[-50%] translate-y-[-50%] sm:max-w-4xl sm:h-auto sm:max-h-[calc(100vh-4rem)] sm:rounded-[calc(var(--ui-radius)*2)] sm:shadow-lg sm:ring ring-[var(--ui-border)]',
+            content: 'top-[50%] left-[50%] translate-x-[-50%] translate-y-[-50%] sm:max-w-7xl sm:h-full sm:max-h-[calc(100vh-10rem)] sm:rounded-[calc(var(--ui-radius)*2)] sm:shadow-lg sm:ring ring-[var(--ui-border)]',
           },
         },
       },

--- a/components/CalendarForm.vue
+++ b/components/CalendarForm.vue
@@ -3,6 +3,7 @@ import type { FormSubmitEvent } from '@nuxt/ui'
 import type { VEvent } from 'node-ical'
 import type { RuleField, RuleType } from '~/types'
 import { ruleFields, ruleTypes } from '~/types'
+import CalendarPreviewModal from './CalendarPreviewModal.vue'
 import NewCalendarModal from './NewCalendarModal.vue'
 
 const props = defineProps<{
@@ -138,9 +139,18 @@ function deleteCalendar() {
           <p v-else-if="error" class="text-red-500 dark:text-red-400">
             An error has occured: make sure the URL is a valid iCalendar URL
           </p>
-          <p v-else>
-            Found a total of {{ data?.events.length }} events
-          </p>
+          <div v-else class="flex items-center gap-2">
+            <p>Found a total of {{ data?.events.length }} events</p>
+            <UTooltip text="Show a preview of the calendar">
+              <UButton
+                size="sm"
+                color="neutral"
+                variant="ghost"
+                icon="i-heroicons-question-mark-circle"
+                @click="modal.open(CalendarPreviewModal, { events: data?.events ?? [] })"
+              />
+            </UTooltip>
+          </div>
         </div>
       </div>
 
@@ -198,10 +208,21 @@ function deleteCalendar() {
           </UButtonGroup>
         </UForm>
 
-        <div class="flex items-center  gap-2">
-          <p v-if="activeCalendar.rules?.length > 0" class="text-sm text-gray-400">
-            Found {{ filteredEvents.length }} events matching rules
-          </p>
+        <div class="flex items-center gap-2">
+          <div v-if="activeCalendar.rules?.length > 0" class="flex items-center gap-2">
+            <p class="text-sm text-gray-400">
+              Found {{ filteredEvents.length }} events matching rules
+            </p>
+            <UTooltip text="Show a preview of the calendar">
+              <UButton
+                size="sm"
+                color="neutral"
+                variant="ghost"
+                icon="i-heroicons-question-mark-circle"
+                @click="modal.open(CalendarPreviewModal, { events: filteredEvents })"
+              />
+            </UTooltip>
+          </div>
 
           <UButton
             size="sm"

--- a/components/CalendarPreviewModal.vue
+++ b/components/CalendarPreviewModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { CalendarOptions } from '@fullcalendar/core/index.js'
+import type { CalendarOptions, EventContentArg } from '@fullcalendar/core/index.js'
 import type { VEvent } from 'node-ical'
 import timeGridPlugin from '@fullcalendar/timegrid'
 import FullCalendar from '@fullcalendar/vue3'
@@ -12,7 +12,10 @@ const calendarEvents = computed(() => props.events.map(event => ({
   title: event.summary,
   start: event.start,
   end: event.end,
-  description: event.description,
+  extendedProps: {
+    description: event.description,
+    location: event.location,
+  },
 })))
 
 const calendarOptions = computed<CalendarOptions>(() => ({
@@ -49,7 +52,21 @@ const calendarOptions = computed<CalendarOptions>(() => ({
   contentHeight: 'auto',
   scrollTime: '08:00:00',
   dayHeaderFormat: { weekday: 'short', day: 'numeric', omitCommas: true },
+  eventContent: eventToHTML,
 }))
+
+function eventToHTML(arg: EventContentArg) {
+  const title = `<p class="text-sm font-medium line-clamp-2 break-all">${arg.event.title}</p>`
+  const location = `<p class="text-xs line-clamp-1 break-all">${arg.event.extendedProps.location}</p>`
+  return {
+    html: `
+      <div class="flex flex-col">
+        ${title}
+        ${arg.event.extendedProps.location ? location : ''}
+      </div>
+    `,
+  }
+}
 </script>
 
 <template>
@@ -73,9 +90,9 @@ const calendarOptions = computed<CalendarOptions>(() => ({
   @apply overflow-hidden cursor-pointer;
 } */
 
-.fc-timegrid-event .fc-event-main {
+/* .fc-timegrid-event .fc-event-main {
   padding: 0px 2px 0px;
-}
+} */
 
 /* .fc-theme-standard .fc-scrollgrid {
   border: none;

--- a/components/CalendarPreviewModal.vue
+++ b/components/CalendarPreviewModal.vue
@@ -1,0 +1,100 @@
+<script setup lang="ts">
+import type { CalendarOptions } from '@fullcalendar/core/index.js'
+import type { VEvent } from 'node-ical'
+import timeGridPlugin from '@fullcalendar/timegrid'
+import FullCalendar from '@fullcalendar/vue3'
+
+const props = defineProps<{
+  events: VEvent[]
+}>()
+
+const calendarEvents = computed(() => props.events.map(event => ({
+  title: event.summary,
+  start: event.start,
+  end: event.end,
+  description: event.description,
+})))
+
+const calendarOptions = computed<CalendarOptions>(() => ({
+  locale: 'en',
+  plugins: [timeGridPlugin],
+  events: [...calendarEvents.value],
+  // layout
+  views: {
+    timeGridThreeDays: {
+      type: 'timeGrid',
+      duration: { days: 3 },
+      buttonText: '3 day',
+    },
+  },
+  initialView: 'timeGridWeek',
+  nowIndicator: true,
+  eventTimeFormat: {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  },
+  slotEventOverlap: true,
+  slotLabelFormat: {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  },
+  // headerToolbar: false, // TODO: disable this once we've implemented custom control buttons
+  firstDay: 1, // start the week on monday
+  allDaySlot: true,
+  allDayText: '',
+  slotDuration: '00:30:00',
+  expandRows: true,
+  contentHeight: 'auto',
+  scrollTime: '08:00:00',
+  dayHeaderFormat: { weekday: 'short', day: 'numeric', omitCommas: true },
+}))
+</script>
+
+<template>
+  <UModal fullscreen>
+    <template #title>
+      Calendar preview
+    </template>
+
+    <template #body>
+      <div>
+        <FullCalendar
+          :options="calendarOptions"
+        />
+      </div>
+    </template>
+  </UModal>
+</template>
+
+<style>
+/* .fc-event-main {
+  @apply overflow-hidden cursor-pointer;
+} */
+
+.fc-timegrid-event .fc-event-main {
+  padding: 0px 2px 0px;
+}
+
+/* .fc-theme-standard .fc-scrollgrid {
+  border: none;
+} */
+
+/* .fc-theme-standard td, .fc-theme-standard th {
+  @apply border-gray-200 dark:border-gray-700;
+} */
+
+.fc-col-header-cell-cushion {
+  @apply capitalize;
+  direction: rtl;
+}
+
+/* For all-day events */
+/* .fc .fc-daygrid-body-natural .fc-daygrid-day-events {
+  @apply mb-0;
+}
+.fc .fc-daygrid-body-unbalanced .fc-daygrid-day-events {
+  @apply min-h-0 cursor-pointer;
+} */
+</style>

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "test": "vitest"
   },
   "dependencies": {
+    "@fullcalendar/core": "^6.1.15",
+    "@fullcalendar/timegrid": "^6.1.15",
+    "@fullcalendar/vue3": "^6.1.15",
     "@nuxt/ui": "3.0.0-alpha.10",
     "@nuxtjs/robots": "5.0.1",
     "@nuxtjs/sitemap": "7.0.0",

--- a/pages/edit/[id].vue
+++ b/pages/edit/[id].vue
@@ -7,15 +7,17 @@ useSeoMeta({
 const route = useRoute()
 const { activeCalendar, calendars } = useCalendars()
 
-if (!activeCalendar.value.id) {
-  const calendar = calendars.value.find(cal => cal.id === route.params.id)
-  if (calendar) {
-    activeCalendar.value = calendar
+onMounted(() => {
+  if (!activeCalendar.value.id) {
+    const calendar = calendars.value.find(cal => cal.id === route.params.id)
+    if (calendar) {
+      activeCalendar.value = calendar
+    }
+    else {
+      navigateTo('/new')
+    }
   }
-  else {
-    navigateTo('/new')
-  }
-}
+})
 </script>
 
 <template>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@fullcalendar/core':
+        specifier: ^6.1.15
+        version: 6.1.15
+      '@fullcalendar/timegrid':
+        specifier: ^6.1.15
+        version: 6.1.15(@fullcalendar/core@6.1.15)
+      '@fullcalendar/vue3':
+        specifier: ^6.1.15
+        version: 6.1.15(@fullcalendar/core@6.1.15)(vue@3.5.13(typescript@5.7.2))
       '@nuxt/ui':
         specifier: 3.0.0-alpha.10
         version: 3.0.0-alpha.10(@babel/parser@7.26.3)(axios@1.7.9)(change-case@5.4.4)(embla-carousel@8.5.1)(ioredis@5.4.1)(magicast@0.3.5)(radix-vue@1.9.11(vue@3.5.13(typescript@5.7.2)))(rollup@4.28.1)(typescript@5.7.2)(vite@5.4.11(@types/node@22.10.2)(lightningcss@1.28.2)(terser@5.37.0))(vue@3.5.13(typescript@5.7.2))
@@ -667,6 +676,25 @@ packages:
 
   '@floating-ui/vue@1.1.5':
     resolution: {integrity: sha512-ynL1p5Z+woPVSwgMGqeDrx6HrJfGIDzFyESFkyqJKilGW1+h/8yVY29Khn0LaU6wHBRwZ13ntG6reiHWK6jyzw==}
+
+  '@fullcalendar/core@6.1.15':
+    resolution: {integrity: sha512-BuX7o6ALpLb84cMw1FCB9/cSgF4JbVO894cjJZ6kP74jzbUZNjtwffwRdA+Id8rrLjT30d/7TrkW90k4zbXB5Q==}
+
+  '@fullcalendar/daygrid@6.1.15':
+    resolution: {integrity: sha512-j8tL0HhfiVsdtOCLfzK2J0RtSkiad3BYYemwQKq512cx6btz6ZZ2RNc/hVnIxluuWFyvx5sXZwoeTJsFSFTEFA==}
+    peerDependencies:
+      '@fullcalendar/core': ~6.1.15
+
+  '@fullcalendar/timegrid@6.1.15':
+    resolution: {integrity: sha512-61ORr3A148RtxQ2FNG7JKvacyA/TEVZ7z6I+3E9Oeu3dqTf6M928bFcpehRTIK6zIA6Yifs7BeWHgOE9dFnpbw==}
+    peerDependencies:
+      '@fullcalendar/core': ~6.1.15
+
+  '@fullcalendar/vue3@6.1.15':
+    resolution: {integrity: sha512-ctfTICGrNEIj7gmLHQcUYe0WzDTSW5Vd9hyOnVChxPU75AZU9WqdDMkHwJYnfNxNhT6QQuiMHq/qsRRd5zQwOw==}
+    peerDependencies:
+      '@fullcalendar/core': ~6.1.15
+      vue: ^3.0.11
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -3974,6 +4002,9 @@ packages:
     resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
     engines: {node: ^10 || ^12 || >=14}
 
+  preact@10.12.1:
+    resolution: {integrity: sha512-l8386ixSsBdbreOAkqtrwqHwdvR35ID8c3rKPa8lCWuO86dBi32QWHV4vfsZK1utLLFMvw+Z5Ad4XLkZzchscg==}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -5529,6 +5560,24 @@ snapshots:
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
+
+  '@fullcalendar/core@6.1.15':
+    dependencies:
+      preact: 10.12.1
+
+  '@fullcalendar/daygrid@6.1.15(@fullcalendar/core@6.1.15)':
+    dependencies:
+      '@fullcalendar/core': 6.1.15
+
+  '@fullcalendar/timegrid@6.1.15(@fullcalendar/core@6.1.15)':
+    dependencies:
+      '@fullcalendar/core': 6.1.15
+      '@fullcalendar/daygrid': 6.1.15(@fullcalendar/core@6.1.15)
+
+  '@fullcalendar/vue3@6.1.15(@fullcalendar/core@6.1.15)(vue@3.5.13(typescript@5.7.2))':
+    dependencies:
+      '@fullcalendar/core': 6.1.15
+      vue: 3.5.13(typescript@5.7.2)
 
   '@humanfs/core@0.19.1': {}
 
@@ -9728,6 +9777,8 @@ snapshots:
       nanoid: 3.3.8
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  preact@10.12.1: {}
 
   prelude-ls@1.2.1: {}
 


### PR DESCRIPTION
# Description

This PR aims to implement a new feature to visualize both input and output events:

- **input:** helps users identify event data to create their filters
- **output:** provides a quick overview of the resulting output after applying filters

# Todo

- [x] **PoC**: Integrate [FullCalendar](https://fullcalendar.io/)
- [ ] **Event field support:** Ensure all fields specified in the source are displayed in the calendars (otherwise, it will be difficult to create filters based on them)
- [ ] **Grid view:** Display events in a weekly grid view
- [ ] **List view:** List all events grouped by date
- [ ] **Form integration:** Design a visually appealing and convenient way to integrate the preview within the `<CalendarForm />`