### PR TITLE
feat: add `esc` kb shortcut to go back to calendars list

### DIFF
--- a/pages/edit/[id].vue
+++ b/pages/edit/[id].vue
@@ -16,6 +16,12 @@ if (!activeCalendar.value.id) {
     navigateTo('/new')
   }
 }
+
+defineShortcuts({
+  escape: () => {
+    navigateTo('/list')
+  },
+})
 </script>
 
 <template>

--- a/pages/new.vue
+++ b/pages/new.vue
@@ -3,6 +3,12 @@ useSeoMeta({
   title: 'New calendar - iCalFilter',
   description: 'Create a calendar with a custom name and URL, and add filtering rules.',
 })
+
+defineShortcuts({
+  escape: () => {
+    navigateTo('/list')
+  },
+})
 </script>
 
 <template>


### PR DESCRIPTION
# Description

Add a keyboard shortcut (`escape`) to go back to the calendars list page from the new/edit calendar pages